### PR TITLE
Added CoreBoy.Avalonia project to provide cross-platform GUI for the emulator

### DIFF
--- a/CoreBoy.Avalonia/App.xaml
+++ b/CoreBoy.Avalonia/App.xaml
@@ -1,0 +1,8 @@
+﻿<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CoreBoy.Avalonia.App">
+    <Application.Styles>
+        <StyleInclude Source="avares://Avalonia.Themes.Default/DefaultTheme.xaml"/>
+        <StyleInclude Source="avares://Avalonia.Themes.Default/Accents/BaseLight.xaml"/>
+    </Application.Styles>
+</Application>

--- a/CoreBoy.Avalonia/App.xaml.cs
+++ b/CoreBoy.Avalonia/App.xaml.cs
@@ -1,0 +1,24 @@
+﻿using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+
+namespace CoreBoy.Avalonia
+{
+    public class App : Application
+    {
+        public override void Initialize()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        public override void OnFrameworkInitializationCompleted()
+        {
+            if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+            {
+                desktop.MainWindow = new MainWindow();
+            }
+
+            base.OnFrameworkInitializationCompleted();
+        }
+    }
+}

--- a/CoreBoy.Avalonia/CoreBoy.Avalonia.csproj
+++ b/CoreBoy.Avalonia/CoreBoy.Avalonia.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Update="**\*.xaml.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+    <AvaloniaResource Include="**\*.xaml">
+      <SubType>Designer</SubType>
+    </AvaloniaResource>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia" Version="0.9.9" />
+    <PackageReference Include="Avalonia.Desktop" Version="0.9.9" />
+    <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.9" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ReactiveUI" Version="11.3.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CoreBoy\CoreBoy.csproj" />
+  </ItemGroup>
+</Project>

--- a/CoreBoy.Avalonia/GlobalSuppressions.cs
+++ b/CoreBoy.Avalonia/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Setter needed in order to dinamically construct the ViewModels in the MainWindow constructor", Scope = "member", Target = "~P:CoreBoy.Avalonia.MenuItemViewModel.Items")]

--- a/CoreBoy.Avalonia/MainWindow.xaml
+++ b/CoreBoy.Avalonia/MainWindow.xaml
@@ -1,0 +1,36 @@
+﻿<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+        x:Class="CoreBoy.Avalonia.MainWindow"
+        Title="CoreBoy"
+        >
+  <Grid Background="Gray">
+
+    <Grid.RowDefinitions>
+      <RowDefinition MaxHeight="20"></RowDefinition>
+      <RowDefinition></RowDefinition>
+    </Grid.RowDefinitions>
+
+    <DockPanel Background="White" Grid.Row="0">
+      <Menu DockPanel.Dock="Top" Items="{Binding MenuItems}">
+
+        <Menu.Styles>
+          <Style Selector="MenuItem">
+            <Setter Property="Header" Value="{Binding Header}"/>
+            <Setter Property="Items" Value="{Binding Items}"/>
+            <Setter Property="Command" Value="{Binding Command}"/>
+            <Setter Property="CommandParameter" Value="{Binding CommandParameter}"/>
+          </Style>
+        </Menu.Styles>
+
+      </Menu>
+    </DockPanel>
+
+    <Image x:Name="ImageBox" Grid.Row ="1">
+
+    </Image>
+
+  </Grid>
+</Window>

--- a/CoreBoy.Avalonia/MainWindow.xaml.cs
+++ b/CoreBoy.Avalonia/MainWindow.xaml.cs
@@ -1,0 +1,338 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using CoreBoy.controller;
+using CoreBoy.gui;
+using ReactiveUI;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Button = CoreBoy.controller.Button;
+
+namespace CoreBoy.Avalonia
+{
+    public class MainWindow : Window, IController, IDisposable
+    {
+        #region Private fields
+
+        private bool isDisposed;
+        private readonly object _updateLock = new object();
+
+        private IButtonListener _listener;
+        private Dictionary<Key, Button> _controls;
+        private byte[] _lastFrame;
+        private readonly Emulator _emulator;
+        private readonly GameboyOptions _gameboyOptions;
+        private CancellationTokenSource _cancellation;
+
+        #endregion
+
+        #region Constructor
+
+        public MainWindow()
+        {
+            Opened += OnWindowOpenedBindWindowEvents;
+            InitializeComponent();
+#if DEBUG
+            this.AttachDevTools();
+#endif
+
+            BuildMenuViewModel();
+            BindKeysToButtons();
+            AdjustEmulatorScreenSize();
+
+            _cancellation = new CancellationTokenSource();
+            _gameboyOptions = new GameboyOptions();
+            _emulator = new Emulator(_gameboyOptions);
+
+            ConnectEmulatorToUI();
+        }
+
+        private void OnWindowOpenedBindWindowEvents(object sender, EventArgs e)
+        {
+            PropertyChanged += OnWindowSizeChanged;
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+
+        private void BuildMenuViewModel()
+        {
+            var vm = new MainWindowViewModel();
+
+            vm.MenuItems = new[]
+                {
+                new MenuItemViewModel()
+                {
+                    Header = "_Emulator",
+                    Items = new[]
+                    {
+                        new MenuItemViewModel()
+                        {
+                            Header = "_Load ROM",
+                            Command = ReactiveCommand.CreateFromTask(LoadROM)
+                        },
+                        new MenuItemViewModel()
+                        {
+                            Header = "_Pause",
+                            Command = ReactiveCommand.Create(Pause)
+                        },
+                        new MenuItemViewModel()
+                        {
+                            Header = "_Quit",
+                            Command = ReactiveCommand.Create(Quit)
+                        }
+                    }
+                },
+                new MenuItemViewModel()
+                {
+                    Header = "Graphics",
+                    Items = new[]
+                    {
+                        new MenuItemViewModel()
+                        {
+                            Header = "Screenshot",
+                            Command = ReactiveCommand.CreateFromTask(Screenshot)
+                        }
+                    }
+                }
+            };
+
+            DataContext = vm;
+        }
+
+        private void BindKeysToButtons()
+        {
+            _controls = new Dictionary<Key, Button>
+            {
+                {Key.Left, Button.Left},
+                {Key.Right, Button.Right},
+                {Key.Up, Button.Up},
+                {Key.Down, Button.Down},
+                {Key.Z, Button.A},
+                {Key.X, Button.B},
+                {Key.Enter, Button.Start},
+                {Key.Back, Button.Select}
+            };
+        }
+
+        private void AdjustEmulatorScreenSize()
+        {
+            var imageBox = this.FindControl<Image>("ImageBox");
+            if (imageBox != null)
+            {
+                imageBox.Width = BitmapDisplay.DisplayWidth * 5;
+                imageBox.Height = BitmapDisplay.DisplayHeight * 5;
+
+                MinHeight = imageBox.Height + 25;
+                MinWidth = imageBox.Width;
+
+                Height = imageBox.Height + 25;
+                Width = imageBox.Width;
+            }
+        }
+
+        private void ConnectEmulatorToUI()
+        {
+            _emulator.Controller = this;
+            _emulator.Display.OnFrameProduced += UpdateDisplay;
+
+            KeyDown += EmulatorSurface_KeyDown;
+            KeyUp += EmulatorSurface_KeyUp;
+            Closed += (_, e) => { _cancellation.Cancel(); };
+        }
+
+        #endregion
+
+        #region Menu Items command methods
+
+        private async Task LoadROM()
+        {
+            if (_emulator.Active)
+            {
+                _emulator.Stop(_cancellation);
+                _cancellation = new CancellationTokenSource();
+                Thread.Sleep(100);
+            }
+
+            OpenFileDialog openFileDialog = new OpenFileDialog()
+            {
+                AllowMultiple = false
+            };
+
+            if (openFileDialog.Filters == null)
+                openFileDialog.Filters = new List<FileDialogFilter>();
+
+            openFileDialog.Filters.Add(new FileDialogFilter()
+            {
+                Name = "Gameboy ROM (*.gb)",
+                Extensions = { "gb" }
+            });
+            openFileDialog.Filters.Add(new FileDialogFilter()
+            {
+                Name = "All files(*.*)",
+                Extensions = { "*.*" }
+            });
+
+            var results = await openFileDialog.ShowAsync(this).ConfigureAwait(true);
+
+            var (success, romPath) = results.Any()
+                ? (true, results.FirstOrDefault())
+                : (false, null);
+
+            if (success)
+            {
+                _gameboyOptions.Rom = romPath;
+                _emulator.Run(_cancellation.Token);
+            }
+        }
+
+        private void Pause()
+        {
+            _emulator.TogglePause();
+        }
+
+        private void Quit()
+        {
+            Close();
+        }
+
+        private async Task Screenshot()
+        {
+            _emulator.TogglePause();
+
+            SaveFileDialog saveFileDialog = new SaveFileDialog();
+
+            if (saveFileDialog.Filters == null)
+                saveFileDialog.Filters = new List<FileDialogFilter>();
+
+            saveFileDialog.Filters.Add(new FileDialogFilter()
+            {
+                Name = "Bitmap (*.bmp)",
+                Extensions = { "*.bmp" }
+            });
+
+            var result = await saveFileDialog.ShowAsync(this).ConfigureAwait(true);
+
+            var (success, screenshotPath) = !string.IsNullOrWhiteSpace(result)
+                ? (true, result)
+                : (false, null);
+
+            if (success)
+            {
+                try
+                {
+                    Monitor.Enter(_updateLock);
+                    File.WriteAllBytes(screenshotPath, _lastFrame);
+                }
+                finally
+                {
+                    Monitor.Exit(_updateLock);
+                }
+            }
+
+            _emulator.TogglePause();
+        }
+
+        #endregion
+
+        #region Emulator events
+
+        private void OnWindowSizeChanged(object sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property.Name.Equals("ClientSize", StringComparison.CurrentCulture))
+            {
+                var imageBox = this.FindControl<Image>("ImageBox");
+                if (imageBox != null)
+                {
+                    imageBox.Width = Width;
+                    imageBox.Height = Height - 25;
+                }
+            }
+        }
+
+        public void UpdateDisplay(object sender, byte[] frame)
+        {
+            if (!Monitor.TryEnter(_updateLock)) return;
+
+            try
+            {
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    _lastFrame = frame;
+                    using var memoryStream = new MemoryStream(frame);
+
+                    var imageBox = this.FindControl<Image>("ImageBox");
+                    if (imageBox != null)
+                    {
+                        imageBox.Source = new Bitmap(memoryStream);
+                    }
+                });
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+            }
+            finally
+            {
+                Monitor.Exit(_updateLock);
+            }
+        }
+
+        private void EmulatorSurface_KeyDown(object sender, KeyEventArgs e)
+        {
+            var button = _controls.ContainsKey(e.Key) ? _controls[e.Key] : null;
+            if (button != null)
+            {
+                _listener?.OnButtonPress(button);
+            }
+        }
+
+        private void EmulatorSurface_KeyUp(object sender, KeyEventArgs e)
+        {
+            var button = _controls.ContainsKey(e.Key) ? _controls[e.Key] : null;
+            if (button != null)
+            {
+                _listener?.OnButtonRelease(button);
+            }
+        }
+
+        #endregion
+
+        #region IController methods
+
+        public void SetButtonListener(IButtonListener listener) => _listener = listener;
+
+        #endregion
+
+        #region IDisposable pattern
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed) return;
+
+            if (disposing)
+            {
+                _cancellation.Dispose();
+            }
+
+            isDisposed = true;
+        }
+
+        #endregion
+    }
+}

--- a/CoreBoy.Avalonia/MainWindowViewModel.cs
+++ b/CoreBoy.Avalonia/MainWindowViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace CoreBoy.Avalonia
+{
+    public class MainWindowViewModel
+    {
+        public IReadOnlyList<MenuItemViewModel> MenuItems { get; set; }
+    }
+}

--- a/CoreBoy.Avalonia/MenuItemViewModel.cs
+++ b/CoreBoy.Avalonia/MenuItemViewModel.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Windows.Input;
+
+namespace CoreBoy.Avalonia
+{
+    public class MenuItemViewModel
+    {
+        public string Header { get; set; }
+        public ICommand Command { get; set; }
+        public object CommandParameter { get; set; }
+        public IList<MenuItemViewModel> Items { get; set; }
+    }
+}

--- a/CoreBoy.Avalonia/Program.cs
+++ b/CoreBoy.Avalonia/Program.cs
@@ -1,0 +1,22 @@
+﻿using Avalonia;
+using Avalonia.Logging.Serilog;
+using Avalonia.ReactiveUI;
+
+namespace CoreBoy.Avalonia
+{
+    class Program
+    {
+        // Initialization code. Don't use any Avalonia, third-party APIs or any
+        // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
+        // yet and stuff might break.
+        public static void Main(string[] args) => BuildAvaloniaApp()
+            .StartWithClassicDesktopLifetime(args);
+
+        // Avalonia configuration, don't remove; also used by visual designer.
+        public static AppBuilder BuildAvaloniaApp()
+            => AppBuilder.Configure<App>()
+                .UseReactiveUI()
+                .UsePlatformDetect()
+                .LogToDebug();
+    }
+}

--- a/CoreBoy.Avalonia/nuget.config
+++ b/CoreBoy.Avalonia/nuget.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- 
+  To use the Avalonia CI feed to get unstable packages, move this file to the root of your solution.
+-->
+
+<configuration>
+  <packageSources>
+    <add key="AvaloniaCI" value="https://www.myget.org/F/avalonia-ci/api/v2" />
+  </packageSources>
+</configuration>

--- a/CoreBoy.sln
+++ b/CoreBoy.sln
@@ -9,9 +9,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreBoy.Test.Unit", "CoreBo
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreBoy.Test.Integration", "CoreBoy.Test.Integration\CoreBoy.Test.Integration.csproj", "{EAB44CCA-A65A-48CC-8ABB-096205788883}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBoy.Windows", "CoreBoy.Windows\CoreBoy.Windows.csproj", "{66AA473C-2F18-4A72-8F96-5F5A3E05F706}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreBoy.Windows", "CoreBoy.Windows\CoreBoy.Windows.csproj", "{66AA473C-2F18-4A72-8F96-5F5A3E05F706}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CoreBoy.Cli", "CoreBoy.Cli\CoreBoy.Cli.csproj", "{FB968AD4-425E-4BE5-8467-0DAD35591C62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreBoy.Cli", "CoreBoy.Cli\CoreBoy.Cli.csproj", "{FB968AD4-425E-4BE5-8467-0DAD35591C62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CoreBoy.Avalonia", "CoreBoy.Avalonia\CoreBoy.Avalonia.csproj", "{B0420E38-BB16-4F15-AFA4-523531D53135}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{FB968AD4-425E-4BE5-8467-0DAD35591C62}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FB968AD4-425E-4BE5-8467-0DAD35591C62}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FB968AD4-425E-4BE5-8467-0DAD35591C62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B0420E38-BB16-4F15-AFA4-523531D53135}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B0420E38-BB16-4F15-AFA4-523531D53135}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B0420E38-BB16-4F15-AFA4-523531D53135}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B0420E38-BB16-4F15-AFA4-523531D53135}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CoreBoy/CoreBoy.csproj
+++ b/CoreBoy/CoreBoy.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -7,7 +7,6 @@
     <RootNamespace>CoreBoy</RootNamespace>
     <AssemblyName>CoreBoy</AssemblyName>
     <StartupObject></StartupObject>
-    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CoreBoy/gui/Emulator.cs
+++ b/CoreBoy/gui/Emulator.cs
@@ -19,7 +19,7 @@ namespace CoreBoy.gui
         public bool Active { get; set; }
 
         private readonly List<Thread> _runnables;
-        
+
         public Emulator(GameboyOptions options)
         {
             _runnables = new List<Thread>();
@@ -65,12 +65,16 @@ namespace CoreBoy.gui
             {
                 return;
             }
-            
+
             source.Cancel();
             _runnables.Clear();
         }
 
-        public void TogglePause() => Gameboy.Pause = !Gameboy.Pause;
+        public void TogglePause()
+        {
+            if (Gameboy != null)
+                Gameboy.Pause = !Gameboy.Pause;
+        }
 
         private Gameboy CreateGameboy(Cartridge rom)
         {

--- a/CoreBoy/gui/Emulator.cs
+++ b/CoreBoy/gui/Emulator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using CoreBoy.controller;
 using CoreBoy.gpu;
@@ -90,7 +91,10 @@ namespace CoreBoy.gui
             //controller = new SwingController(properties);
             //gameboy = new Gameboy(options, rom, display, controller, sound, serialEndpoint, console);
 
-            return new Gameboy(Options, rom, Display, Controller, new WinSound(), SerialEndpoint);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return new Gameboy(Options, rom, Display, Controller, new WinSound(), SerialEndpoint);
+
+            return new Gameboy(Options, rom, Display, Controller, new NullSoundOutput(), SerialEndpoint);
         }
     }
 }

--- a/readme.md
+++ b/readme.md
@@ -26,13 +26,7 @@ Just run `CoreBoy.Windows` and load a ROM from the file menu!
 
 Command line:
 
-```bash
-dotnet CoreBoy.Cli -r myrom.rom --interactive
-```
-
-You can play on the command line!
-
-GUI ...TBC
+Just run `CoreBoy.Avalonia` and load a ROM from the file menu!
 
 # Controls
 


### PR DESCRIPTION
- Implemented **cross-platform GUI** for the emulator using AvaloniaUI and ReactiveUI frameworks (built on .NET Core 3.1)
- Fixed NullReferenceException in **TogglePause()** method that caused **Pause** and **Screenshot** buttons to crash the app
- Minor update to **readme.md**